### PR TITLE
to use a animation scheduler to update all animation at a time, so th…

### DIFF
--- a/lib/animation-scheduler.js
+++ b/lib/animation-scheduler.js
@@ -1,0 +1,94 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _spriteTimeline = require('sprite-timeline');
+
+var _spriteTimeline2 = _interopRequireDefault(_spriteTimeline);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var isBrowser = typeof document !== 'undefined' && document.documentElement && document.documentElement.contains;
+
+var AnimationScheduler = function () {
+  function AnimationScheduler() {
+    (0, _classCallCheck3.default)(this, AnimationScheduler);
+    this._animations = [];
+  }
+
+  (0, _createClass3.default)(AnimationScheduler, [{
+    key: 'add',
+    value: function add(animation) {
+      this._animations.push(animation);
+      this.scheduleAnimation();
+    }
+  }, {
+    key: 'scheduleAnimation',
+    value: function scheduleAnimation() {
+      var _this = this;
+
+      if (this.requestId) return;
+      this.requestId = requestAnimationFrame(function () {
+        var ntime = _spriteTimeline2.default.nowtime();
+        _this.updateFrame(ntime);
+      });
+    }
+  }, {
+    key: 'updateFrame',
+    value: function updateFrame(ntime) {
+      var nullAnimationCount = 0;
+      var scheduleNext = false;
+      for (var i = 0; i < this._animations.length; i++) {
+        var animation = this._animations[i];
+        if (animation === null) {
+          nullAnimationCount++;
+          continue;
+        }
+        var sprite = animation.target;
+
+        if (isBrowser && sprite.layer && sprite.layer.canvas && !document.documentElement.contains(sprite.layer.canvas)) {
+          // if dom element has been removed stop animation.
+          // it usually occurs in single page applications.
+          animation.cancel();
+          this._animations[i] = null;
+          continue;
+        }
+        var playState = animation.getPlayState(ntime);
+        sprite.attr(animation.getFrame(ntime));
+        if (playState === 'idle') {
+          this._animations[i] = null;
+          continue;
+        }
+        if (playState === 'running') {
+          scheduleNext = true;
+        } else if (playState === 'paused' || playState === 'pending' && animation.timeline.getCurrentTime(ntime) < 0) {
+          // playbackRate < 0 will cause playState reset to pending...
+          this.add(animation);
+        }
+      }
+      // if there are more than 10 animation is finished we do a cleaning, avoid GC.
+      if (nullAnimationCount > 10) {
+        this._animations = this._animations.filter(function (i) {
+          return i !== null;
+        });
+      }
+      if (scheduleNext) {
+        this.requestId = null;
+        this.scheduleAnimation();
+      }
+    }
+  }]);
+  return AnimationScheduler;
+}();
+
+exports.default = new AnimationScheduler();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sprite-core",
-  "version": "2.14.2",
+  "version": "2.14.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "css-line-break": "^1.0.1",
     "fast-animation-frame": "^0.3.3",
     "sprite-animator": "^1.10.4",
+    "sprite-timeline": "^1.9.2",
     "sprite-math": "^1.0.4",
     "sprite-utils": "^1.11.4",
     "svg-path-to-canvas": "^1.9.5"

--- a/src/animation-scheduler.js
+++ b/src/animation-scheduler.js
@@ -1,0 +1,68 @@
+import Timeline from 'sprite-timeline';
+
+const isBrowser = typeof document !== 'undefined'
+  && document.documentElement
+  && document.documentElement.contains;
+
+class AnimationScheduler {
+  _animations = []
+  add(animation) {
+    this._animations.push(animation);
+    this.scheduleAnimation();
+  }
+
+
+  scheduleAnimation() {
+    if(this.requestId) return;
+    this.requestId = requestAnimationFrame(() => {
+      var ntime = Timeline.nowtime();
+      this.updateFrame(ntime);
+    });
+  }
+
+  updateFrame(ntime) {
+    var nullAnimationCount = 0;
+    var scheduleNext = false;
+    for(var i = 0; i < this._animations.length; i++) {
+      let animation = this._animations[i];
+      if(animation === null) {
+        nullAnimationCount++;
+        continue;
+      }
+      let sprite = animation.target;
+
+      if(isBrowser
+        && sprite.layer
+        && sprite.layer.canvas
+        && !document.documentElement.contains(sprite.layer.canvas)) {
+        // if dom element has been removed stop animation.
+        // it usually occurs in single page applications.
+        animation.cancel();
+        this._animations[i] = null;
+        continue;
+      }
+      const playState = animation.getPlayState(ntime);
+      sprite.attr(animation.getFrame(ntime));
+      if(playState === 'idle') {
+        this._animations[i] = null;
+        continue;
+      }
+      if(playState === 'running') {
+        scheduleNext = true;
+      } else if(playState === 'paused' || playState === 'pending' && animation.timeline.getCurrentTime(ntime) < 0) {
+        // playbackRate < 0 will cause playState reset to pending...
+        this.add(animation)
+      }
+    }
+    // if there are more than 10 animation is finished we do a cleaning, avoid GC.
+    if(nullAnimationCount > 10) {
+      this._animations = this._animations.filter(i => i !== null);
+    }
+    if(scheduleNext) {
+      this.requestId = null;
+      this.scheduleAnimation();
+    }
+  }
+}
+
+export default new AnimationScheduler();

--- a/src/animation.js
+++ b/src/animation.js
@@ -137,7 +137,7 @@ export default class extends Animator {
 
   finish() {
     super.finish();
-    cancelAnimationFrame(this.requestId);
+    animationScheduler.delete(this);
     const sprite = this.target;
     sprite.attr(this.frame);
   }
@@ -149,12 +149,9 @@ export default class extends Animator {
     if(!sprite.parent || this.getPlayState(ntime) === 'running') {
       return;
     }
-
     super.play(ntime);
     sprite.attr(this.getFrame(ntime));
-    this.ready.then(() => {
-      animationScheduler.add(this);
-    });
+    animationScheduler.add(this);
   }
 
   cancel(preserveState = false) {

--- a/src/animation.js
+++ b/src/animation.js
@@ -4,7 +4,7 @@ import {Matrix} from 'sprite-math';
 import {parseColor, parseStringTransform} from 'sprite-utils';
 // to use Timeline.nowtime, fast-animation-frame also implement nowtime, should be extract to use the same code.
 import Timeline from 'sprite-timeline';
-
+import animationScheduler from './animation-scheduler';
 const defaultEffect = Effects.default;
 
 function arrayEffect(arr1, arr2, p, start, end) {


### PR DESCRIPTION
…at to use one nowtime for all calculation, benchmark show for animation sprites larger than 1000 we have 20% more fps gain. this commit depends on two other commmit in sprite-timeline and sprite-animation as bellow:
https://github.com/spritejs/sprite-animator/pull/1
https://github.com/spritejs/sprite-timeline/pull/1