### PR TITLE
 fix arrayEffect arr1 is array arr2 is not array

### DIFF
--- a/src/modules/animation/animation.js
+++ b/src/modules/animation/animation.js
@@ -46,7 +46,9 @@ function arrayEffect(arr1, arr2, p, start, end) {
     arr2 = parseStringFloat(arr2);
   }
   if(Array.isArray(arr1)) {
-    return arr1.map((o, i) => defaultEffect(o, arr2[i] || arr2, p, start, end));
+    return arr1.map((o, i) =>
+      defaultEffect(o, arr2[i] != null ? arr2[i] : arr2, p, start, end)
+    );
   }
   return defaultEffect(arr1, arr2, p, start, end);
 }

--- a/src/modules/animation/animation.js
+++ b/src/modules/animation/animation.js
@@ -1,59 +1,51 @@
-import { Animator, Effects } from "sprite-animator";
-import { Matrix } from "sprite-math";
-import {
-  parseColor,
-  parseStringFloat,
-  parseStringTransform,
-  createSvgPath
-} from "../../utils";
-import dEffect from "./patheffect";
-import {
-  requestAnimationFrame,
-  cancelAnimationFrame
-} from "../../helpers/fast-animation-frame";
+import {Animator, Effects} from 'sprite-animator';
+import {Matrix} from 'sprite-math';
+import {parseColor, parseStringFloat, parseStringTransform, createSvgPath} from '../../utils';
+import dEffect from './patheffect';
+import {requestAnimationFrame, cancelAnimationFrame} from '../../helpers/fast-animation-frame';
 
 const _defaultEffect = Effects.default;
 
 const defaultEffect = (from, to, p, start, end) => {
-  let unitFrom = "px",
-    unitTo = "px";
+  let unitFrom = 'px',
+    unitTo = 'px';
   let matchFrom = null,
     matchTo = null;
 
   const exp = /^([\d.]+)(%|rh|rw)$/i;
-  if (typeof from === "string") {
+  if(typeof from === 'string') {
     matchFrom = exp.exec(from);
-    if (matchFrom) {
+    if(matchFrom) {
       unitFrom = matchFrom[2];
     }
   }
 
-  if (typeof to === "string") {
+  if(typeof to === 'string') {
     matchTo = exp.exec(to);
-    if (matchTo) {
+    if(matchTo) {
       unitTo = matchTo[2];
     }
   }
 
-  if (unitFrom === unitTo) {
-    if (matchFrom) from = parseFloat(matchFrom[1]);
-    if (matchTo) to = parseFloat(matchTo[1]);
+  if(unitFrom === unitTo) {
+    if(matchFrom) from = parseFloat(matchFrom[1]);
+    if(matchTo) to = parseFloat(matchTo[1]);
   }
 
   const v = _defaultEffect(from, to, p, start, end);
-  return unitFrom !== "px" ? `${v}${unitFrom}` : v;
+  return unitFrom !== 'px' ? `${v}${unitFrom}` : v;
 };
 
 Effects.default = defaultEffect;
 
 function arrayEffect(arr1, arr2, p, start, end) {
-  if (typeof arr1 === "string") {
+  if(typeof arr1 === 'string') {
     arr1 = parseStringFloat(arr1);
   }
-  if (typeof arr2 === "string") {
+  if(typeof arr2 === 'string') {
     arr2 = parseStringFloat(arr2);
   }
-  if (Array.isArray(arr1)) {
+  if(Array.isArray(arr1)) {
     return arr1.map((o, i) => defaultEffect(o, arr2[i] || arr2, p, start, end));
   }
   return defaultEffect(arr1, arr2, p, start, end);
@@ -73,11 +65,11 @@ function objectEffect(obj1, obj2, p, start, end) {
 function getTransformMatrix(trans) {
   let matrix = new Matrix();
   Object.entries(trans).forEach(([key, val]) => {
-    if (key === "matrix") {
+    if(key === 'matrix') {
       matrix = new Matrix(val);
-    } else if (Array.isArray(val)) {
+    } else if(Array.isArray(val)) {
       matrix[key](...val);
-    } else if (key === "scale") {
+    } else if(key === 'scale') {
       matrix.scale(val, val);
     } else {
       matrix[key](val);
@@ -87,9 +79,9 @@ function getTransformMatrix(trans) {
 }
 
 function arrayEqual(arr1, arr2) {
-  if (arr1.length !== arr2.length) return false;
-  for (let i = 0; i < arr1.length; i++) {
-    if (arr1[i] !== arr2[i]) {
+  if(arr1.length !== arr2.length) return false;
+  for(let i = 0; i < arr1.length; i++) {
+    if(arr1[i] !== arr2[i]) {
       return false;
     }
   }
@@ -100,12 +92,12 @@ function transformEffect(trans1, trans2, p, start, end) {
   trans1 = parseStringTransform(trans1);
   trans2 = parseStringTransform(trans2);
 
-  if (!arrayEqual(Object.keys(trans1), Object.keys(trans2))) {
+  if(!arrayEqual(Object.keys(trans1), Object.keys(trans2))) {
     trans1 = getTransformMatrix(trans1);
     trans2 = getTransformMatrix(trans2);
   }
 
-  if (Array.isArray(trans1) || Array.isArray(trans2)) {
+  if(Array.isArray(trans1) || Array.isArray(trans2)) {
     return arrayEffect(trans1, trans2, p, start, end);
   }
   return objectEffect(trans1, trans2, p, start, end);
@@ -115,7 +107,7 @@ function colorEffect(color1, color2, p, start, end) {
   const c1 = parseColor(color1);
   const c2 = parseColor(color2);
 
-  if (c1.model === c2.model) {
+  if(c1.model === c2.model) {
     c1.value = arrayEffect(c1.value, c2.value, p, start, end).map((c, i) => {
       return i < 3 ? Math.round(c) : Math.round(c * 100) / 100;
     });
@@ -141,13 +133,13 @@ Object.assign(Effects, {
   transform: transformEffect,
   bgcolor: colorEffect,
   border(v1, v2, p, start, end) {
-    if (Array.isArray(v2)) {
-      v2 = { width: v2[0], color: v2[1], style: v2[2] || "solid" };
+    if(Array.isArray(v2)) {
+      v2 = {width: v2[0], color: v2[1], style: v2[2] || 'solid'};
     }
     return {
       width: defaultEffect(v1.width, v2.width, p, start, end),
       color: colorEffect(v1.color, v2.color, p, start, end),
-      style: arrayEffect(v1.style, v2.style, p, start, end)
+      style: arrayEffect(v1.style, v2.style, p, start, end),
     };
   },
   scale: arrayEffect,
@@ -160,23 +152,19 @@ Object.assign(Effects, {
   fillColor: colorEffect,
   d: dEffect,
   path: pathEffect,
-  clip: pathEffect
+  clip: pathEffect,
 });
 
 export default class extends Animator {
   constructor(sprite, frames, timing, setter) {
     super(sprite.attr(), frames, timing);
     this.target = sprite;
-    this.setter =
-      setter ||
-      function(frame, target) {
-        target.attr(frame);
-      };
+    this.setter = setter || function (frame, target) { target.attr(frame) };
   }
 
   get playState() {
-    if (!this.target.parent) {
-      return "idle";
+    if(!this.target.parent) {
+      return 'idle';
     }
     return super.playState;
   }
@@ -188,11 +176,11 @@ export default class extends Animator {
     // the animator is still running
     return super.finished.then(() => {
       const that = this;
-      return new Promise(resolve => {
+      return new Promise((resolve) => {
         function update() {
           that.setter(that.frame, that.target);
           const playState = that.playState;
-          if (playState === "finished" || playState === "idle") {
+          if(playState === 'finished' || playState === 'idle') {
             cancelAnimationFrame(that.requestId);
             resolve();
           } else {
@@ -204,15 +192,14 @@ export default class extends Animator {
     });
   }
 
-  finish() {
-    // finish should change attrs synchronously
+  finish() { // finish should change attrs synchronously
     super.finish();
     cancelAnimationFrame(this.requestId);
     this.setter(this.frame, this.target);
   }
 
   play() {
-    if (!this.target.parent || this.playState === "running") {
+    if(!this.target.parent || this.playState === 'running') {
       return;
     }
 
@@ -225,14 +212,12 @@ export default class extends Animator {
       that.setter(that.frame, that.target);
       that.requestId = requestAnimationFrame(function update() {
         const target = that.target;
-        if (
-          typeof document !== "undefined" &&
-          document.documentElement &&
-          document.documentElement.contains &&
-          target.layer &&
-          target.layer.canvas &&
-          !document.documentElement.contains(target.layer.canvas)
-        ) {
+        if(typeof document !== 'undefined'
+          && document.documentElement
+          && document.documentElement.contains
+          && target.layer
+          && target.layer.canvas
+          && !document.documentElement.contains(target.layer.canvas)) {
           // if dom element has been removed stop animation.
           // it usually occurs in single page applications.
           that.cancel();
@@ -240,13 +225,10 @@ export default class extends Animator {
         }
         const playState = that.playState;
         that.setter(that.frame, that.target);
-        if (playState === "idle") return;
-        if (playState === "running") {
+        if(playState === 'idle') return;
+        if(playState === 'running') {
           that.requestId = requestAnimationFrame(update);
-        } else if (
-          playState === "paused" ||
-          (playState === "pending" && that.timeline.currentTime < 0)
-        ) {
+        } else if(playState === 'paused' || playState === 'pending' && that.timeline.currentTime < 0) {
           // playbackRate < 0 will cause playState reset to pending...
           that.ready.then(() => {
             that.setter(that.frame, that.target);
@@ -259,7 +241,7 @@ export default class extends Animator {
 
   cancel(preserveState = false) {
     cancelAnimationFrame(this.requestId);
-    if (preserveState) {
+    if(preserveState) {
       this.setter(this.frame, this.target);
       super.cancel();
     } else {

--- a/src/modules/animation/animation.js
+++ b/src/modules/animation/animation.js
@@ -1,52 +1,60 @@
-import {Animator, Effects} from 'sprite-animator';
-import {Matrix} from 'sprite-math';
-import {parseColor, parseStringFloat, parseStringTransform, createSvgPath} from '../../utils';
-import dEffect from './patheffect';
-import {requestAnimationFrame, cancelAnimationFrame} from '../../helpers/fast-animation-frame';
+import { Animator, Effects } from "sprite-animator";
+import { Matrix } from "sprite-math";
+import {
+  parseColor,
+  parseStringFloat,
+  parseStringTransform,
+  createSvgPath
+} from "../../utils";
+import dEffect from "./patheffect";
+import {
+  requestAnimationFrame,
+  cancelAnimationFrame
+} from "../../helpers/fast-animation-frame";
 
 const _defaultEffect = Effects.default;
 
 const defaultEffect = (from, to, p, start, end) => {
-  let unitFrom = 'px',
-    unitTo = 'px';
+  let unitFrom = "px",
+    unitTo = "px";
   let matchFrom = null,
     matchTo = null;
 
   const exp = /^([\d.]+)(%|rh|rw)$/i;
-  if(typeof from === 'string') {
+  if (typeof from === "string") {
     matchFrom = exp.exec(from);
-    if(matchFrom) {
+    if (matchFrom) {
       unitFrom = matchFrom[2];
     }
   }
 
-  if(typeof to === 'string') {
+  if (typeof to === "string") {
     matchTo = exp.exec(to);
-    if(matchTo) {
+    if (matchTo) {
       unitTo = matchTo[2];
     }
   }
 
-  if(unitFrom === unitTo) {
-    if(matchFrom) from = parseFloat(matchFrom[1]);
-    if(matchTo) to = parseFloat(matchTo[1]);
+  if (unitFrom === unitTo) {
+    if (matchFrom) from = parseFloat(matchFrom[1]);
+    if (matchTo) to = parseFloat(matchTo[1]);
   }
 
   const v = _defaultEffect(from, to, p, start, end);
-  return unitFrom !== 'px' ? `${v}${unitFrom}` : v;
+  return unitFrom !== "px" ? `${v}${unitFrom}` : v;
 };
 
 Effects.default = defaultEffect;
 
 function arrayEffect(arr1, arr2, p, start, end) {
-  if(typeof arr1 === 'string') {
+  if (typeof arr1 === "string") {
     arr1 = parseStringFloat(arr1);
   }
-  if(typeof arr2 === 'string') {
+  if (typeof arr2 === "string") {
     arr2 = parseStringFloat(arr2);
   }
-  if(Array.isArray(arr1)) {
-    return arr1.map((o, i) => defaultEffect(o, arr2[i], p, start, end));
+  if (Array.isArray(arr1)) {
+    return arr1.map((o, i) => defaultEffect(o, arr2[i] || arr2, p, start, end));
   }
   return defaultEffect(arr1, arr2, p, start, end);
 }
@@ -65,11 +73,11 @@ function objectEffect(obj1, obj2, p, start, end) {
 function getTransformMatrix(trans) {
   let matrix = new Matrix();
   Object.entries(trans).forEach(([key, val]) => {
-    if(key === 'matrix') {
+    if (key === "matrix") {
       matrix = new Matrix(val);
-    } else if(Array.isArray(val)) {
+    } else if (Array.isArray(val)) {
       matrix[key](...val);
-    } else if(key === 'scale') {
+    } else if (key === "scale") {
       matrix.scale(val, val);
     } else {
       matrix[key](val);
@@ -79,9 +87,9 @@ function getTransformMatrix(trans) {
 }
 
 function arrayEqual(arr1, arr2) {
-  if(arr1.length !== arr2.length) return false;
-  for(let i = 0; i < arr1.length; i++) {
-    if(arr1[i] !== arr2[i]) {
+  if (arr1.length !== arr2.length) return false;
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) {
       return false;
     }
   }
@@ -92,12 +100,12 @@ function transformEffect(trans1, trans2, p, start, end) {
   trans1 = parseStringTransform(trans1);
   trans2 = parseStringTransform(trans2);
 
-  if(!arrayEqual(Object.keys(trans1), Object.keys(trans2))) {
+  if (!arrayEqual(Object.keys(trans1), Object.keys(trans2))) {
     trans1 = getTransformMatrix(trans1);
     trans2 = getTransformMatrix(trans2);
   }
 
-  if(Array.isArray(trans1) || Array.isArray(trans2)) {
+  if (Array.isArray(trans1) || Array.isArray(trans2)) {
     return arrayEffect(trans1, trans2, p, start, end);
   }
   return objectEffect(trans1, trans2, p, start, end);
@@ -107,7 +115,7 @@ function colorEffect(color1, color2, p, start, end) {
   const c1 = parseColor(color1);
   const c2 = parseColor(color2);
 
-  if(c1.model === c2.model) {
+  if (c1.model === c2.model) {
     c1.value = arrayEffect(c1.value, c2.value, p, start, end).map((c, i) => {
       return i < 3 ? Math.round(c) : Math.round(c * 100) / 100;
     });
@@ -133,13 +141,13 @@ Object.assign(Effects, {
   transform: transformEffect,
   bgcolor: colorEffect,
   border(v1, v2, p, start, end) {
-    if(Array.isArray(v2)) {
-      v2 = {width: v2[0], color: v2[1], style: v2[2] || 'solid'};
+    if (Array.isArray(v2)) {
+      v2 = { width: v2[0], color: v2[1], style: v2[2] || "solid" };
     }
     return {
       width: defaultEffect(v1.width, v2.width, p, start, end),
       color: colorEffect(v1.color, v2.color, p, start, end),
-      style: arrayEffect(v1.style, v2.style, p, start, end),
+      style: arrayEffect(v1.style, v2.style, p, start, end)
     };
   },
   scale: arrayEffect,
@@ -152,19 +160,23 @@ Object.assign(Effects, {
   fillColor: colorEffect,
   d: dEffect,
   path: pathEffect,
-  clip: pathEffect,
+  clip: pathEffect
 });
 
 export default class extends Animator {
   constructor(sprite, frames, timing, setter) {
     super(sprite.attr(), frames, timing);
     this.target = sprite;
-    this.setter = setter || function (frame, target) { target.attr(frame) };
+    this.setter =
+      setter ||
+      function(frame, target) {
+        target.attr(frame);
+      };
   }
 
   get playState() {
-    if(!this.target.parent) {
-      return 'idle';
+    if (!this.target.parent) {
+      return "idle";
     }
     return super.playState;
   }
@@ -176,11 +188,11 @@ export default class extends Animator {
     // the animator is still running
     return super.finished.then(() => {
       const that = this;
-      return new Promise((resolve) => {
+      return new Promise(resolve => {
         function update() {
           that.setter(that.frame, that.target);
           const playState = that.playState;
-          if(playState === 'finished' || playState === 'idle') {
+          if (playState === "finished" || playState === "idle") {
             cancelAnimationFrame(that.requestId);
             resolve();
           } else {
@@ -192,14 +204,15 @@ export default class extends Animator {
     });
   }
 
-  finish() { // finish should change attrs synchronously
+  finish() {
+    // finish should change attrs synchronously
     super.finish();
     cancelAnimationFrame(this.requestId);
     this.setter(this.frame, this.target);
   }
 
   play() {
-    if(!this.target.parent || this.playState === 'running') {
+    if (!this.target.parent || this.playState === "running") {
       return;
     }
 
@@ -212,12 +225,14 @@ export default class extends Animator {
       that.setter(that.frame, that.target);
       that.requestId = requestAnimationFrame(function update() {
         const target = that.target;
-        if(typeof document !== 'undefined'
-          && document.documentElement
-          && document.documentElement.contains
-          && target.layer
-          && target.layer.canvas
-          && !document.documentElement.contains(target.layer.canvas)) {
+        if (
+          typeof document !== "undefined" &&
+          document.documentElement &&
+          document.documentElement.contains &&
+          target.layer &&
+          target.layer.canvas &&
+          !document.documentElement.contains(target.layer.canvas)
+        ) {
           // if dom element has been removed stop animation.
           // it usually occurs in single page applications.
           that.cancel();
@@ -225,10 +240,13 @@ export default class extends Animator {
         }
         const playState = that.playState;
         that.setter(that.frame, that.target);
-        if(playState === 'idle') return;
-        if(playState === 'running') {
+        if (playState === "idle") return;
+        if (playState === "running") {
           that.requestId = requestAnimationFrame(update);
-        } else if(playState === 'paused' || playState === 'pending' && that.timeline.currentTime < 0) {
+        } else if (
+          playState === "paused" ||
+          (playState === "pending" && that.timeline.currentTime < 0)
+        ) {
           // playbackRate < 0 will cause playState reset to pending...
           that.ready.then(() => {
             that.setter(that.frame, that.target);
@@ -241,7 +259,7 @@ export default class extends Animator {
 
   cancel(preserveState = false) {
     cancelAnimationFrame(this.requestId);
-    if(preserveState) {
+    if (preserveState) {
       this.setter(this.frame, this.target);
       super.cancel();
     } else {


### PR DESCRIPTION
当前 arrayEffect 存在 arr1 为 数组，但 arr2 可能不为数组 导致计算异常的问题，例如：
一个元素从 `scale=[2, 2]` 过渡到  `scale=0.5` 可能最终导致元素的 `scale=[-0.001, -0.001]`。

```js
const s = new Sprite();

s.attr({
  pos: [400, 300],
  size: [20, 20],
  bgcolor: 'red',
  state: 'normal',
  states: { hover: { scale: 0.5 }, normal: { scale: [2, 3]} }
});

s.on('mouseenter', () => {
    s.attr('state', 'hover')
    console.log(s.attr('scale'))
})

s.on('mouseleave', () => {
   s.attr('state', 'normal')
   console.log(s.attr('scale'))
})
```